### PR TITLE
Added LoRaWAN Specs and air time calculator tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Este repositorio pretende listar todos aquellos recursos que vaya encontrando co
 - 🇪🇸 Lista de reproducción de [Introducción a LoRa/LoRaWAN](https://youtu.be/qs7Lz9g-mgg) creada por [Biblioman](https://twitter.com/biblioman09/)
 - 🇬🇧 Lista de reproducción sobre LoRa, LoRaWAN y Sigfox de [Andreas Spiess](https://www.youtube.com/watch?v=hMOwbNUpDQA&list=PL3XBzmAj53Rkkogh-lti58h_GkhzU1n7U)
 
-
 ## Redes LoRaWAN comunitarias abiertas más conocidas
 - [The Things Network](https://www.thethingsnetwork.org/)
 - [Helium - The People's Network](https://www.helium.com/)
 - [LORIOT](https://www.loriot.io/)
 
 ## LoRa Alliance (enlaces importantes)
+- Especificación LoRaWAN [v1.0.2](https://lora-alliance.org/resource_hub/lorawan-specification-v1-0-2/) / [v1.0.3](https://lora-alliance.org/resource_hub/lorawan-specification-v1-0-3/) / [v1.0.4](https://lora-alliance.org/resource_hub/lorawan-104-specification-package/)
+- Parámetros regionales de LoRaWAN [v1.0.1](https://lora-alliance.org/resource_hub/rp2-101-lorawan-regional-parameters-2/) / [v1.0.2rB](https://lora-alliance.org/resource_hub/lorawan-regional-parameters-v1-0-2rb/) / [RP2-1.0.2](https://lora-alliance.org/resource_hub/rp2-102-lorawan-regional-parameters/) / [v1.0.3](https://lora-alliance.org/resource_hub/rp2-1-0-3-lorawan-regional-parameters/)
 - [Mapa de Operadores y cobertura de LoRaWAN](https://lora-alliance.org/lorawan-coverage/)
-- Parámetros regionales de LoRaWAN [1.0.1](https://lora-alliance.org/resource_hub/rp2-101-lorawan-regional-parameters-2/) / [1.0.2](https://lora-alliance.org/resource_hub/rp2-102-lorawan-regional-parameters/) / [1.0.3](https://lora-alliance.org/resource_hub/rp2-1-0-3-lorawan-regional-parameters/)
 
 ## Plataformas IOT
 - [AdafruitIO](https://io.adafruit.com/)
@@ -44,3 +44,7 @@ Este repositorio pretende listar todos aquellos recursos que vaya encontrando co
 - [Arduino IOT Cloud](https://create.arduino.cc/iot/things)
 - [Losant](https://www.losant.com/)
 - [ThingSpeak](https://thingspeak.com/)
+
+## Herramientas
+
+- [Herramienta de cálculo de tiempo en aire](https://avbentem.github.io/airtime-calculator/ttn/eu868)


### PR DESCRIPTION
Hi,

- Added missing LoRaWAN Protocol Specifications versions.

- Added missing LoRaWAN Regional Parameters v1.0.2 revision B (note that v1.0.2revB is different than RP2-1.0.2).

- Added Airtime Calculator Tool.

Regards.